### PR TITLE
userChrome.css: changed rounding on and increased position priority of sidebar-box

### DIFF
--- a/FirefoxCSS/Full/Linux/Mac/userChrome.css
+++ b/FirefoxCSS/Full/Linux/Mac/userChrome.css
@@ -116,7 +116,8 @@ findbar{border-radius: 10px 10px 0 0 !important; margin-top: -10px; z-index: 2; 
 #urlbar:not([open]){color: currentColor!important} #urlbar[open]{color: var(--toolbar-field-focus-color)}
 
 /*  Makes sidebars nicer  */
-#sidebar-box{margin-top: -10px !important;border-radius: 10px 10px 0 0!important}
+#sidebar-box{margin-top: -10px !important; border-radius: 0 10px 0 0!important; z-index: 1}
+#sidebar-box[positionend="true"]{border-radius: 10px 0 0 0!important}
 #sidebar-box > *{background-image:none;}
 
 /*  Drop menus  */

--- a/FirefoxCSS/Full/Linux/Win/userChrome.css
+++ b/FirefoxCSS/Full/Linux/Win/userChrome.css
@@ -122,7 +122,8 @@ findbar{border-radius: 10px 10px 0 0 !important; margin-top: -10px; z-index: 2; 
 #urlbar:not([open]){color: currentColor!important} #urlbar[open]{color: var(--toolbar-field-focus-color)}
 
 /*  Makes sidebars nicer  */
-#sidebar-box{margin-top: -10px !important;border-radius: 10px 10px 0 0!important}
+#sidebar-box{margin-top: -10px !important; border-radius: 0 10px 0 0!important; z-index: 1}
+#sidebar-box[positionend="true"]{border-radius: 10px 0 0 0!important}
 #sidebar-box > *{background-image:none;}
 
 /*  Drop menus  */

--- a/FirefoxCSS/Full/Win11/userChrome.css
+++ b/FirefoxCSS/Full/Win11/userChrome.css
@@ -124,7 +124,8 @@ findbar{border-radius: 10px 10px 0 0 !important; margin-top: -10px; z-index: 2; 
 #urlbar:not([open]){color: currentColor!important} #urlbar[open]{color: var(--toolbar-field-focus-color)}
 
 /*  Makes sidebars nicer  */
-#sidebar-box{margin-top: -10px !important;border-radius: 10px 10px 0 0!important}
+#sidebar-box{margin-top: -10px !important; border-radius: 0 10px 0 0!important; z-index: 1}
+#sidebar-box[positionend="true"]{border-radius: 10px 0 0 0!important}
 #sidebar-box > *{background-image:none;}
 
 /*  Drop menus  */

--- a/FirefoxCSS/Full/userChrome.css
+++ b/FirefoxCSS/Full/userChrome.css
@@ -129,7 +129,8 @@ findbar{border-radius: 10px 10px 0 0 !important; margin-top: -10px; z-index: 2; 
 #urlbar:not([open]){color: currentColor!important} #urlbar[open]{color: var(--toolbar-field-focus-color)}
 
 /*  Makes sidebars nicer  */
-#sidebar-box{margin-top: -10px !important;border-radius: 10px 10px 0 0!important}
+#sidebar-box{margin-top: -10px !important; border-radius: 0 10px 0 0!important; z-index: 1}
+#sidebar-box[positionend="true"]{border-radius: 10px 0 0 0!important}
 #sidebar-box > *{background-image:none;}
 
 /*  Drop menus  */

--- a/FirefoxCSS/Minimal/userChrome.css
+++ b/FirefoxCSS/Minimal/userChrome.css
@@ -126,7 +126,8 @@ findbar{border-radius: 10px 10px 0 0 !important; margin-top: -10px; z-index: 2; 
 #urlbar:not([open]){color: currentColor!important} #urlbar[open]{color: var(--toolbar-field-focus-color)}
 
 /*  Makes sidebars nicer  */
-#sidebar-box{margin-top: -10px !important;border-radius: 10px 10px 0 0!important}
+#sidebar-box{margin-top: -10px !important; border-radius: 0 10px 0 0!important; z-index: 1}
+#sidebar-box[positionend="true"]{border-radius: 10px 0 0 0!important}
 #sidebar-box > *{background-image:none;}
 
 /*  Drop menus  */


### PR DESCRIPTION
Made some changes because I felt the styling when using tree style tab was off.


I didn't like the rounding for the sidebar corners closest to the edge:
![image](https://github.com/Bali10050/FirefoxCSS/assets/133264129/dd4359cc-4152-44f0-a6eb-c07728eb2779)

So I changed it to this:
![image](https://github.com/Bali10050/FirefoxCSS/assets/133264129/ce5627b2-670b-4506-99d2-bfa507a4c3c2)


The sidebar would also be overshadowed when the window was not focused:
![image](https://github.com/Bali10050/FirefoxCSS/assets/133264129/ec0752f3-4043-435c-af3a-906e50bf1568)


So I increased the position priority of the sidebar so now it looks like this unfocused:
![image](https://github.com/Bali10050/FirefoxCSS/assets/133264129/4d0238f1-15c9-4982-bbcf-a83928a0ef8c)

