### PR TITLE
Fix urlbar background removal not working

### DIFF
--- a/chrome/userChrome.css
+++ b/chrome/userChrome.css
@@ -49,7 +49,7 @@
 #tabs-newtab-button > .toolbarbutton-icon , #new-tab-button > .toolbarbutton-icon{ background: none !important;}
 
 /*  Removes urlbar border/background  */
-#urlbar-background{border: none !important; outline: none !important; transition: .15s !important;}
+.urlbar-background{border: none !important; outline: none !important; transition: .15s !important;}
 
 /*  Cool animation on tab/bookmark icons  */
 .tabbrowser-tab:not([pinned]):not([selected]) .tab-icon-image ,.bookmark-item .toolbarbutton-icon{opacity: 0!important; transition: .15s !important; width: 0!important; padding-left: 16px!important}
@@ -99,7 +99,7 @@
 #alltabs-button>.toolbarbutton-badge-stack::before {content: counter(tabCount); color: var(--toolbarbutton-icon-fill) !important; position: absolute; top: 16.5px; left: 50%; transform: translate(-50%,-30%); padding: 0 3px}
 
 /*  Removes the background from the urlbar while not in use  */
-#urlbar:not(:hover):not([breakout][breakout-extend])>#urlbar-background {box-shadow: none!important; background: #0000 !important}
+#urlbar:not(:hover):not([breakout][breakout-extend])>.urlbar-background {box-shadow: none !important; background: #0000 !important; transition: .6s ease-out !important}
 
 /*  Urlbar popup thing  */
 .urlbarView-row{display: none !important}


### PR DESCRIPTION
To remove background from the URL bar the code looks for a `#urlbar-background` element id, but it appears to be a class instead, so it should be `.urlbar-background`, this gets it working for me.

Additionally added a transition effect when the background is revealed on hover so it looks less jarring.

![moddedfirefox2-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/4334a04a-fe0e-41f1-a97e-4d12333dd676)
